### PR TITLE
Attribute bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 			<url>https://build.devotedmc.com/plugin/repository/everything/</url>
 		</repository>
 		<repository>
-			<id>dmulloy2-repo</id>
-			<url>http://repo.dmulloy2.net/content/groups/public/</url>
+			<id>byteflux-repo</id>
+			<url>http://repo.byteflux.net/repository/maven-public/</url>
 		</repository>
 	</repositories>
 </project>

--- a/src/main/java/com/github/maxopoly/finale/misc/WeaponModifier.java
+++ b/src/main/java/com/github/maxopoly/finale/misc/WeaponModifier.java
@@ -6,6 +6,9 @@ import java.util.Map;
 import org.bukkit.Material;
 
 public class WeaponModifier {
+	
+	public static final int DAMAGE_NON_ADJUSTED = -1;
+	public static final double ATTACK_SPEED_NON_ADJUSTED = -1.0d;
 
 	private class WeaponConfig {
 		private Material mat;
@@ -31,11 +34,7 @@ public class WeaponModifier {
 		}
 	}
 
-	private Map<Material, WeaponConfig> weapons;
-
-	public WeaponModifier() {
-		weapons = new HashMap<Material, WeaponModifier.WeaponConfig>();
-	}
+	private Map<Material, WeaponConfig> weapons = new HashMap<>();
 
 	public void addWeapon(Material m, int damage, double attackSpeed) {
 		weapons.put(m, new WeaponConfig(m, damage, attackSpeed));
@@ -44,7 +43,7 @@ public class WeaponModifier {
 	public int getDamage(Material m) {
 		WeaponConfig config = weapons.get(m);
 		if (config == null) {
-			return -1;
+			return DAMAGE_NON_ADJUSTED;
 		}
 		return config.getDamage();
 	}
@@ -52,7 +51,7 @@ public class WeaponModifier {
 	public double getAttackSpeed(Material m) {
 		WeaponConfig config = weapons.get(m);
 		if (config == null) {
-			return -1.0;
+			return ATTACK_SPEED_NON_ADJUSTED;
 		}
 		return config.getAttackSpeed();
 	}


### PR DESCRIPTION
Fixed a rather innocuous bug as it didn't do much except clutter the NBT data of an item, but when Finale now sets the damage and attack speed for an item, it will no longer set duplicate entries, nor will it keep duplicate entries. It will only remove attributes that are identical.

I figure that Finale will be updated or removed for 1.14, so I'm aware that this work might not be relevant towards that, but this bug is frustrating enough right now that I decided to fix it :P