### PR TITLE
Fix knockback swords not giving as much knockback as they should.

### DIFF
--- a/src/main/java/com/github/maxopoly/finale/ConfigParser.java
+++ b/src/main/java/com/github/maxopoly/finale/ConfigParser.java
@@ -363,8 +363,10 @@ public class ConfigParser {
 			double toughness = current.getDouble("toughness", -1);
 			double armour = current.getDouble("armour", -1);
 			double knockbackResistance = current.getDouble("knockbackResistance", -1);
-			plugin.info("Modifying " + matString + ": toughness: " + toughness + ", armour: " + armour + ", knockbackResistance: " + knockbackResistance);
-			am.addArmour(mat, toughness, armour, knockbackResistance);
+			int extraDurabilityHits = current.getInt("extraDurabilityHits", 0);
+			plugin.info("Modifying " + matString + ": toughness: " + toughness + ", armour: " + armour
+					+ ", knockbackResistance: " + knockbackResistance, ", extraDurabilityHits: " + extraDurabilityHits);
+			am.addArmour(mat, toughness, armour, knockbackResistance, extraDurabilityHits);
 		}
 		return am;
 	}

--- a/src/main/java/com/github/maxopoly/finale/ConfigParser.java
+++ b/src/main/java/com/github/maxopoly/finale/ConfigParser.java
@@ -411,6 +411,7 @@ public class ConfigParser {
 		boolean sprintResetEnabled = config.getBoolean("sprintResetEnabled", true);
 		boolean waterSprintResetEnabled = config.getBoolean("waterSprintResetEnabled", false);
 		boolean sweepEnabled = config.getBoolean("sweepEnabled", false);
+		double knockbackLevelMultiplier = config.getDouble("knockbackLevelMultiplier", 0.6);
 		int cpsLimit = 9;
 		long cpsCounterInterval = 1000;
 		if (config.isConfigurationSection("cps")) {
@@ -420,7 +421,7 @@ public class ConfigParser {
 		}
 
 		return new CombatConfig(attackCooldownEnabled, knockbackSwordsEnabled, sprintResetEnabled, waterSprintResetEnabled, cpsLimit, cpsCounterInterval, maxReach, sweepEnabled, combatSounds,
-				knockbackMultiplier, sprintMultiplier, waterKnockbackMultiplier, airKnockbackMultiplier, victimMotion, maxVictimMotion, attackerMotion);
+				knockbackLevelMultiplier, knockbackMultiplier, sprintMultiplier, waterKnockbackMultiplier, airKnockbackMultiplier, victimMotion, maxVictimMotion, attackerMotion);
 	}
 
 	private Vector parseVector(ConfigurationSection config, String name, Vector def) {

--- a/src/main/java/com/github/maxopoly/finale/Finale.java
+++ b/src/main/java/com/github/maxopoly/finale/Finale.java
@@ -1,19 +1,12 @@
 package com.github.maxopoly.finale;
 
+import com.github.maxopoly.finale.listeners.*;
 import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.PluginManager;
 
 import com.github.maxopoly.finale.external.CombatTagPlusManager;
 import com.github.maxopoly.finale.external.FinaleSettingManager;
-import com.github.maxopoly.finale.listeners.DamageListener;
-import com.github.maxopoly.finale.listeners.EnchantmentDisableListener;
-import com.github.maxopoly.finale.listeners.PearlCoolDownListener;
-import com.github.maxopoly.finale.listeners.PlayerListener;
-import com.github.maxopoly.finale.listeners.PotionListener;
-import com.github.maxopoly.finale.listeners.ToolProtectionListener;
-import com.github.maxopoly.finale.listeners.VelocityFixListener;
-import com.github.maxopoly.finale.listeners.WeaponModificationListener;
 import com.github.maxopoly.finale.overlay.ScoreboardHUD;
 
 import vg.civcraft.mc.civmodcore.ACivMod;
@@ -77,6 +70,7 @@ public class Finale extends ACivMod {
 							ctpManager), this);
 		}
 		Bukkit.getPluginManager().registerEvents(new WeaponModificationListener(), this);
+		Bukkit.getPluginManager().registerEvents(new ExtraDurabilityListener(), this);
 		Bukkit.getPluginManager().registerEvents(new EnchantmentDisableListener(config.getDisabledEnchants()), this);
 		Bukkit.getPluginManager().registerEvents(new PotionListener(config.getPotionHandler()), this);
 		Bukkit.getPluginManager().registerEvents(new VelocityFixListener(config.getVelocityHandler()), this);

--- a/src/main/java/com/github/maxopoly/finale/combat/CombatConfig.java
+++ b/src/main/java/com/github/maxopoly/finale/combat/CombatConfig.java
@@ -15,6 +15,7 @@ public class CombatConfig {
 	private double maxReach;
 	private boolean sweepEnabled;
 	private CombatSoundConfig combatSounds;
+	private double knockbackLevelMultiplier;
 	private Vector knockbackMultiplier;
 	private Vector sprintMultiplier;
 	private Vector waterKnockbackMultiplier;
@@ -24,7 +25,7 @@ public class CombatConfig {
 	private Vector attackerMotion;
 
 	public CombatConfig(boolean attackCooldownEnabled, boolean knockbackSwordsEnabled, boolean sprintResetEnabled, boolean waterSprintResetEnabled, int cpsLimit, long cpsCounterInterval, double maxReach, boolean sweepEnabled, CombatSoundConfig combatSounds,
-						Vector knockbackMultiplier, Vector sprintMultiplier, Vector waterKnockbackMultiplier, Vector airKnockbackMultiplier, Vector victimMotion, Vector maxVictimMotion,
+						double knockbackLevelMultiplier, Vector knockbackMultiplier, Vector sprintMultiplier, Vector waterKnockbackMultiplier, Vector airKnockbackMultiplier, Vector victimMotion, Vector maxVictimMotion,
 						Vector attackerMotion) {
 		this.attackCooldownEnabled = attackCooldownEnabled;
 		this.knockbackSwordsEnabled = knockbackSwordsEnabled;
@@ -35,6 +36,7 @@ public class CombatConfig {
 		this.maxReach = maxReach;
 		this.sweepEnabled = sweepEnabled;
 		this.combatSounds = combatSounds;
+		this.knockbackLevelMultiplier = knockbackLevelMultiplier;
 		this.knockbackMultiplier = knockbackMultiplier;
 		this.sprintMultiplier = sprintMultiplier;
 		this.waterKnockbackMultiplier = waterKnockbackMultiplier;
@@ -61,6 +63,10 @@ public class CombatConfig {
 		setVector(config, "clearCombat.attackerMotion", this.attackerMotion);
 		config.options().copyDefaults(true);
 		Finale.getPlugin().saveConfig();
+	}
+
+	public double getKnockbackLevelMultiplier() {
+		return knockbackLevelMultiplier;
 	}
 
 	public Vector getKnockbackMultiplier() {

--- a/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
+++ b/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
@@ -82,8 +82,8 @@ public class CombatUtil {
 			World world = attacker.getWorld();
 			if (damage > 0.0F || f1 > 0.0F) {
 				boolean dealtExtraKnockback = false;
-				byte b0 = 1;
-				int knockbackLevel = b0 + EnchantmentManager.b((EntityLiving) attacker);
+				byte baseKnockbackLevel = 0;
+				int knockbackLevel = baseKnockbackLevel + EnchantmentManager.b((EntityLiving) attacker);
 
 				if (attacker.isSprinting() && shouldKnockback) {
 					if (config.getCombatSounds().isKnockbackEnabled()) {
@@ -143,14 +143,12 @@ public class CombatUtil {
 						EntityLiving livingVictim = (EntityLiving) victim;
 						double kbResistance = livingVictim.b(GenericAttributes.KNOCKBACK_RESISTANCE);
 						double knockbackModifier = (1.0 - kbResistance);
-						if (config.isKnockbackSwordsEnabled() && knockbackLevel > 1) {
-							knockbackModifier *= (knockbackLevel * 0.6f);
-						}
+						double knockbackLevelModifier = 1 + (knockbackLevel * config.getKnockbackLevelMultiplier());
 
 						if (knockbackModifier > 0) {
-							double dx = -MathHelper.sin(attacker.yaw * 0.01745329251f) * 0.3f * knockbackModifier;
+							double dx = -MathHelper.sin(attacker.yaw * 0.01745329251f) * 0.3f;
 							double dy = 0.35;
-							double dz = MathHelper.cos(attacker.yaw * 0.01745329251f) * 0.3f * knockbackModifier;
+							double dz = MathHelper.cos(attacker.yaw * 0.01745329251f) * 0.3f;
 
 							Vector knockbackMultiplier = config.getKnockbackMultiplier();
 							Vector waterKnockbackMultiplier = config.getWaterKnockbackMultiplier();
@@ -176,6 +174,15 @@ public class CombatUtil {
 								dy *= airKnockbackMultiplier.getY();
 								dz *= airKnockbackMultiplier.getZ();
 							}
+
+							if (config.isKnockbackSwordsEnabled() && knockbackLevel > 1) {
+								dx *= knockbackLevelModifier;
+								dz *= knockbackLevelModifier;
+							}
+
+							dx *= knockbackModifier;
+							dy *= knockbackModifier;
+							dz *= knockbackModifier;
 
 							victim.impulse = true;
 

--- a/src/main/java/com/github/maxopoly/finale/listeners/ExtraDurabilityListener.java
+++ b/src/main/java/com/github/maxopoly/finale/listeners/ExtraDurabilityListener.java
@@ -1,0 +1,22 @@
+package com.github.maxopoly.finale.listeners;
+
+import com.github.maxopoly.finale.Finale;
+import com.github.maxopoly.finale.misc.ArmourModifier;
+import com.github.maxopoly.finale.misc.ExtraDurabilityTracker;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class ExtraDurabilityListener implements Listener {
+
+	@EventHandler
+	public void onDurabilityChange(PlayerItemDamageEvent e) {
+		ItemStack is = e.getItem();
+		ArmourModifier armourModifier = Finale.getPlugin().getManager().getArmourModifier();
+		ExtraDurabilityTracker extraDurabilityTracker = armourModifier.getExtraDurabilityTracker();
+		boolean reduce = extraDurabilityTracker.reduceDurability(e.getPlayer(), is.getType());
+		e.setCancelled(!reduce);
+	}
+
+}

--- a/src/main/java/com/github/maxopoly/finale/listeners/WeaponModificationListener.java
+++ b/src/main/java/com/github/maxopoly/finale/listeners/WeaponModificationListener.java
@@ -22,18 +22,40 @@ public class WeaponModificationListener implements Listener {
 		if (is == null) {
 			return;
 		}
+
+		is = ItemUtil.newModifiers(is); // there was a bug where modifiers weren't changing for items with already changed modifiers.
+
+		ArmourModifier armourMod = Finale.getPlugin().getManager().getArmourModifier();
+
+		double toughness = armourMod.getToughness(is.getType());
+		double armour = armourMod.getArmour(is.getType());
+		double knockbackResistance = armourMod.getKnockbackResistance(is.getType());
+
+		if (toughness != -1 || armour != -1 || knockbackResistance != -1) {
+			if (toughness == -1) {
+				toughness = ItemUtil.getDefaultArmourToughness(is);
+			}
+			if (armour == -1) {
+				armour = ItemUtil.getDefaultArmour(is);
+			}
+			if (knockbackResistance == -1) {
+				knockbackResistance = ItemUtil.getDefaultKnockbackResistance(is);
+			}
+			is = ItemUtil.setArmour(ItemUtil.setArmourToughness(ItemUtil.setArmourKnockbackResistance(is, knockbackResistance), toughness), armour);
+		}
+
 		WeaponModifier weaponMod = Finale.getPlugin().getManager().getWeaponModifer();
-		
+
 		double adjustedDamage = weaponMod.getDamage(is.getType());
 		double adjustedAttackSpeed = weaponMod.getAttackSpeed(is.getType());
-		if (adjustedAttackSpeed == -1.0 && adjustedDamage == -1) {
-			return;
+
+		if (adjustedAttackSpeed != -1.0 || adjustedDamage != -1) {
+			is = ItemUtil.setDamage(ItemUtil.setAttackSpeed(is, adjustedAttackSpeed), adjustedDamage);
 		}
-		ItemStack result = ItemUtil.setDamage(ItemUtil.setAttackSpeed(is, adjustedAttackSpeed), adjustedDamage);
-		e.setCurrentItem(result);
+		e.setCurrentItem(is);
 	}
 	
-	@EventHandler
+	/*@EventHandler
 	public void armourMod(InventoryClickEvent e) {
 		ItemStack is = e.getCurrentItem();
 		if (is == null) {
@@ -58,8 +80,9 @@ public class WeaponModificationListener implements Listener {
 			knockbackResistance = ItemUtil.getDefaultKnockbackResistance(is);
 		}
 
+		is = ItemUtil.newModifiers(is);
 		ItemStack result = ItemUtil.setArmour(ItemUtil.setArmourToughness(ItemUtil.setArmourKnockbackResistance(is, knockbackResistance), toughness), armour);
 		e.setCurrentItem(result);
-	}
+	}*/
 
 }

--- a/src/main/java/com/github/maxopoly/finale/listeners/WeaponModificationListener.java
+++ b/src/main/java/com/github/maxopoly/finale/listeners/WeaponModificationListener.java
@@ -54,35 +54,5 @@ public class WeaponModificationListener implements Listener {
 		}
 		e.setCurrentItem(is);
 	}
-	
-	/*@EventHandler
-	public void armourMod(InventoryClickEvent e) {
-		ItemStack is = e.getCurrentItem();
-		if (is == null) {
-			return;
-		}
-		ArmourModifier armourMod = Finale.getPlugin().getManager().getArmourModifier();
-		
-		double toughness = armourMod.getToughness(is.getType());
-		double armour = armourMod.getArmour(is.getType());
-		double knockbackResistance = armourMod.getKnockbackResistance(is.getType());
-
-		if (toughness == -1 && armour == -1 && knockbackResistance == -1) {
-			return;
-		}
-		if (toughness == -1) {
-			toughness = ItemUtil.getDefaultArmourToughness(is);
-		}
-		if (armour == -1) {
-			armour = ItemUtil.getDefaultArmour(is);
-		}
-		if (knockbackResistance == -1) {
-			knockbackResistance = ItemUtil.getDefaultKnockbackResistance(is);
-		}
-
-		is = ItemUtil.newModifiers(is);
-		ItemStack result = ItemUtil.setArmour(ItemUtil.setArmourToughness(ItemUtil.setArmourKnockbackResistance(is, knockbackResistance), toughness), armour);
-		e.setCurrentItem(result);
-	}*/
 
 }

--- a/src/main/java/com/github/maxopoly/finale/listeners/WeaponModificationListener.java
+++ b/src/main/java/com/github/maxopoly/finale/listeners/WeaponModificationListener.java
@@ -4,6 +4,7 @@ package com.github.maxopoly.finale.listeners;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.github.maxopoly.finale.Finale;

--- a/src/main/java/com/github/maxopoly/finale/misc/ArmourModifier.java
+++ b/src/main/java/com/github/maxopoly/finale/misc/ArmourModifier.java
@@ -12,11 +12,16 @@ public class ArmourModifier {
 		private double toughness;
 		private double armour;
 		private double knockbackResistance;
+		private int extraDurabilityHits;
 
 		public ArmourConfig(double toughness, double armour, double knockbackResistance) {
+			this(toughness, armour, knockbackResistance, 0);
+		}
+		public ArmourConfig(double toughness, double armour, double knockbackResistance, int extraDurabilityHits) {
 			this.toughness = toughness;
 			this.armour = armour;
 			this.knockbackResistance = knockbackResistance;
+			this.extraDurabilityHits = extraDurabilityHits;
 		}
 
 		public double getToughness() {
@@ -31,21 +36,27 @@ public class ArmourModifier {
 			return knockbackResistance;
 		}
 
+		public int getExtraDurabilityHits() {
+			return extraDurabilityHits;
+		}
+
 		@Override
 		public String toString() {
 			return "Armour [toughness=" + toughness + ", armour=" + armour + ", kb_resistance=" + knockbackResistance + "]";
 		}
 		
 	}
-	
+
+	private ExtraDurabilityTracker extraDurabilityTracker;
 	private Map<Material, ArmourConfig> armour;
 
 	public ArmourModifier() {
+		this.extraDurabilityTracker = new ExtraDurabilityTracker(this);
 		this.armour = new HashMap<Material, ArmourConfig>();
 	}
 
-	public void addArmour(Material m, double toughness, double armour, double knockbackResistance) {
-		this.armour.put(m, new ArmourConfig(toughness, armour, knockbackResistance));
+	public void addArmour(Material m, double toughness, double armour, double knockbackResistance, int extraDurabilityHits) {
+		this.armour.put(m, new ArmourConfig(toughness, armour, knockbackResistance, extraDurabilityHits));
 	}
 
 	public double getToughness(Material m) {
@@ -71,5 +82,17 @@ public class ArmourModifier {
 		}
 		return config.getKnockbackResistance();
 	}
-	
+
+	public int getExtraDurabilityHits(Material m) {
+		ArmourConfig config = armour.get(m);
+		if (config == null) {
+			return -1;
+		}
+
+		return config.getExtraDurabilityHits();
+	}
+
+	public ExtraDurabilityTracker getExtraDurabilityTracker() {
+		return extraDurabilityTracker;
+	}
 }

--- a/src/main/java/com/github/maxopoly/finale/misc/ExtraDurabilityTracker.java
+++ b/src/main/java/com/github/maxopoly/finale/misc/ExtraDurabilityTracker.java
@@ -1,0 +1,37 @@
+package com.github.maxopoly.finale.misc;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ExtraDurabilityTracker {
+
+	private ArmourModifier armourModifier;
+	private Map<UUID, Map<Material, Integer>> playerExtraHits = new HashMap<>();
+
+	public ExtraDurabilityTracker(ArmourModifier armourModifier) {
+		this.armourModifier = armourModifier;
+	}
+
+	// returns true if durability should reduce, false if durability shouldn't reduce.
+	public boolean reduceDurability(Player player, Material material) {
+		Map<Material, Integer> materialExtraHits = playerExtraHits.getOrDefault(player.getUniqueId(), new HashMap<>());
+		int extraHits = materialExtraHits.containsKey(material) ? materialExtraHits.get(material) : armourModifier.getExtraDurabilityHits(material);
+		boolean reduce = extraHits <= 0;
+		if (reduce) {
+			materialExtraHits.put(material, armourModifier.getExtraDurabilityHits(material));
+		} else {
+			materialExtraHits.put(material, extraHits - 1);
+		}
+		playerExtraHits.put(player.getUniqueId(), materialExtraHits);
+		return reduce;
+	}
+
+	public void clear(Player player) {
+		playerExtraHits.remove(player.getUniqueId());
+	}
+
+}

--- a/src/main/java/com/github/maxopoly/finale/misc/ItemUtil.java
+++ b/src/main/java/com/github/maxopoly/finale/misc/ItemUtil.java
@@ -3,6 +3,7 @@ package com.github.maxopoly.finale.misc;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemStack;
@@ -95,6 +96,14 @@ public class ItemUtil {
 	public static boolean isArmour(ItemStack is) {
 		return isHelmet(is) || isChestplate(is) || isLeggings(is) || isBoots(is);
 	}
+
+	public static ItemStack newModifiers(ItemStack is) {
+		net.minecraft.server.v1_16_R3.ItemStack nmsStack = CraftItemStack.asNMSCopy(is);
+		NBTTagCompound compound = (nmsStack.hasTag()) ? nmsStack.getTag() : new NBTTagCompound();
+		compound.set("AttributeModifiers", new NBTTagList());
+		nmsStack.setTag(compound);
+		return CraftItemStack.asBukkitCopy(nmsStack);
+	}
 	
 	public static net.minecraft.server.v1_16_R3.ItemStack getNMSStack(ItemStack is) {
 		net.minecraft.server.v1_16_R3.ItemStack nmsStack = CraftItemStack.asNMSCopy(is);
@@ -135,16 +144,21 @@ public class ItemUtil {
 		NBTBase valueTag = (value instanceof Double) ? NBTTagDouble.a((Double) value) : NBTTagInt.a((Integer) value);
 		
 		Slot slot = attribute.getSlot();
+
+		/*Optional<NBTTagCompound> existingModifier = modifiers.stream().filter((base) -> base instanceof NBTTagCompound)
+				.map((base) -> (NBTTagCompound) base)
+				.filter((attributeTag) -> attributeTag.getString("AttributeName").equals(attribute.getName())).findFirst();
+		existingModifier.ifPresent(modifiers::remove);*/
 		
-		NBTTagCompound damage = new NBTTagCompound();
-		damage.set("AttributeName", NBTTagString.a(attribute.getName()));
-		damage.set("Name", NBTTagString.a(attribute.getName()));
-		damage.set("Operation", NBTTagInt.a(0));
-		damage.set("Amount", valueTag);
-		damage.set("Slot", NBTTagString.a(slot.getName()));
-		damage.set("UUIDLeast", NBTTagInt.a(slot.getUuidLeast()));
-		damage.set("UUIDMost", NBTTagInt.a(slot.getUuidMost()));
-		modifiers.add(damage);
+		NBTTagCompound attributeTag = new NBTTagCompound();
+		attributeTag.set("AttributeName", NBTTagString.a(attribute.getName()));
+		attributeTag.set("Name", NBTTagString.a(attribute.getName()));
+		attributeTag.set("Operation", NBTTagInt.a(0));
+		attributeTag.set("Amount", valueTag);
+		attributeTag.set("Slot", NBTTagString.a(slot.getName()));
+		attributeTag.set("UUIDLeast", NBTTagInt.a(slot.getUuidLeast()));
+		attributeTag.set("UUIDMost", NBTTagInt.a(slot.getUuidMost()));
+		modifiers.add(attributeTag);
 		
 		compound.set("AttributeModifiers", modifiers);
 		nmsStack.setTag(compound);

--- a/src/main/java/com/github/maxopoly/finale/misc/ItemUtil.java
+++ b/src/main/java/com/github/maxopoly/finale/misc/ItemUtil.java
@@ -144,11 +144,6 @@ public class ItemUtil {
 		NBTBase valueTag = (value instanceof Double) ? NBTTagDouble.a((Double) value) : NBTTagInt.a((Integer) value);
 		
 		Slot slot = attribute.getSlot();
-
-		/*Optional<NBTTagCompound> existingModifier = modifiers.stream().filter((base) -> base instanceof NBTTagCompound)
-				.map((base) -> (NBTTagCompound) base)
-				.filter((attributeTag) -> attributeTag.getString("AttributeName").equals(attribute.getName())).findFirst();
-		existingModifier.ifPresent(modifiers::remove);*/
 		
 		NBTTagCompound attributeTag = new NBTTagCompound();
 		attributeTag.set("AttributeName", NBTTagString.a(attribute.getName()));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,21 +20,22 @@ cleanerCombat:
     strong: false
     knockback: false
     crit: false
+  knockbackLevelMultiplier: 0.6 # a constant to control the knockback sword level
   sprintMultiplier: # modifies knockback if the attacker is sprinting.
-    x: 3.0
+    x: 2.3
     y: 1.0
-    z: 3.0
+    z: 2.3
   knockbackMultiplier: # modifies knockback in general.
+    x: 1.2
+    y: 0.9
+    z: 1.2
+  waterKnockbackMultiplier: # modifies knockback if the victim is in water.
     x: 1.0
     y: 1.0
     z: 1.0
-  waterKnockbackMultiplier: # modifies knockback if the victim is in water.
-    x: 0.7
-    y: 0.7
-    z: 0.7
   airKnockbackMultiplier: # modifies knockback if the victim is in the air
     x: 1.0
-    y: 1.0
+    y: 1.05
     z: 1.0
   attackerMotion: # modifies motion of attacker upon attacking.
     x: 0.6
@@ -109,40 +110,48 @@ weaponModification:
 armourModification:
    diamondHelmet:
       material: DIAMOND_HELMET
+      armour: 3
       toughness: 3
-      extraDurabilityHits: 2 # how many extra hits a player needs to take for the durability of the piece to fall
+      extraDurabilityHits: 1 # how many extra hits a player needs to take for the durability of the piece to fall
    diamondChestplate:
       material: DIAMOND_CHESTPLATE
+      armour: 8
       toughness: 3
-      extraDurabilityHits: 2
+      extraDurabilityHits: 1
    diamondLeggings:
       material: DIAMOND_LEGGINGS
+      armour: 6
       toughness: 3
-      extraDurabilityHits: 2
+      extraDurabilityHits: 1
    diamondBoots:
       material: DIAMOND_BOOTS
+      armour: 3
       toughness: 3
-      extraDurabilityHits: 2
+      extraDurabilityHits: 1
    netheriteHelmet:
      material: NETHERITE_HELMET
-     toughness: 4
-     extraDurabilityHits: 2
+     armour: 4
+     toughness: 5
+     extraDurabilityHits: 1
      knockbackResistance: 0.1 # knockback resistance is a value between 0 and 1.
    netheriteChestplate:
      material: NETHERITE_CHESTPLATE
-     toughness: 4
-     extraDurabilityHits: 2
-     knockbackResistance: 0.1
+     armour: 8
+     toughness: 5
+     extraDurabilityHits: 1
+     knockbackResistance: 0
    netheriteLeggings:
      material: NETHERITE_LEGGINGS
-     toughness: 4
-     extraDurabilityHits: 2
-     knockbackResistance: 0.1
+     armour: 6
+     toughness: 5
+     extraDurabilityHits: 1
+     knockbackResistance: 0
    netheriteBoots:
      material: NETHERITE_BOOTS
-     toughness: 4
-     extraDurabilityHits: 2
-     knockbackResistance: 0.1
+     armour: 4
+     toughness: 5
+     extraDurabilityHits: 1
+     knockbackResistance: 0
 
 #allows disabling enchantments. Use official spigot identifiers from https://hub.spigotmc.org/javadocs/spigot/org/bukkit/enchantments/Enchantment.html
 #This will not remove them from enchanting, but simply remove the enchant as soon as the item is touched
@@ -199,7 +208,7 @@ velocity:
 #of projectiles to the list to revert their behavior regarding initial velocity to 1.7
   ENDER_PEARL:
      type: REVERTED
-     power: 1.2
+     power: 1.4
   SPLASH_POTION:
      type: REVERTED
      power: 0.5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -110,30 +110,38 @@ armourModification:
    diamondHelmet:
       material: DIAMOND_HELMET
       toughness: 3
+      extraDurabilityHits: 2 # how many extra hits a player needs to take for the durability of the piece to fall
    diamondChestplate:
       material: DIAMOND_CHESTPLATE
       toughness: 3
+      extraDurabilityHits: 2
    diamondLeggings:
       material: DIAMOND_LEGGINGS
       toughness: 3
+      extraDurabilityHits: 2
    diamondBoots:
       material: DIAMOND_BOOTS
       toughness: 3
+      extraDurabilityHits: 2
    netheriteHelmet:
      material: NETHERITE_HELMET
      toughness: 4
+     extraDurabilityHits: 2
      knockbackResistance: 0.1 # knockback resistance is a value between 0 and 1.
    netheriteChestplate:
      material: NETHERITE_CHESTPLATE
      toughness: 4
+     extraDurabilityHits: 2
      knockbackResistance: 0.1
    netheriteLeggings:
      material: NETHERITE_LEGGINGS
      toughness: 4
+     extraDurabilityHits: 2
      knockbackResistance: 0.1
    netheriteBoots:
      material: NETHERITE_BOOTS
      toughness: 4
+     extraDurabilityHits: 2
      knockbackResistance: 0.1
 
 #allows disabling enchantments. Use official spigot identifiers from https://hub.spigotmc.org/javadocs/spigot/org/bukkit/enchantments/Enchantment.html

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,6 +69,9 @@ pearls:
   
 #allows adjusting the attack damage of any item by its spigot material identifier
 weaponModification:
+  netheriteAxe:
+    material: NETHERITE_AXE
+    damage: 6
   diamondAxe:
     material: DIAMOND_AXE
     damage: 5
@@ -84,6 +87,9 @@ weaponModification:
   woodAxe:
     material: WOODEN_AXE
     damage: 1
+  netheriteSword:
+    material: NETHERITE_SWORD
+    damage: 7
   diamondSword:
     material: DIAMOND_SWORD
     damage: 6

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,7 +47,7 @@ cleanerCombat:
     z: 0.5
   maxVictimMotion: # maximum motion of victim upon getting hit.
     x: 10.0
-    y: 1.0
+    y: 0.3
     z: 10.0
     
 # gives full control over health / regen, default is full reversion to 1.8 mechanics
@@ -111,45 +111,45 @@ armourModification:
    diamondHelmet:
       material: DIAMOND_HELMET
       armour: 3
-      toughness: 3
+      toughness: 2
       extraDurabilityHits: 1 # how many extra hits a player needs to take for the durability of the piece to fall
    diamondChestplate:
       material: DIAMOND_CHESTPLATE
       armour: 8
-      toughness: 3
+      toughness: 2
       extraDurabilityHits: 1
    diamondLeggings:
       material: DIAMOND_LEGGINGS
       armour: 6
-      toughness: 3
+      toughness: 2
       extraDurabilityHits: 1
    diamondBoots:
       material: DIAMOND_BOOTS
       armour: 3
-      toughness: 3
+      toughness: 2
       extraDurabilityHits: 1
    netheriteHelmet:
      material: NETHERITE_HELMET
      armour: 4
-     toughness: 5
+     toughness: 2
      extraDurabilityHits: 1
-     knockbackResistance: 0.1 # knockback resistance is a value between 0 and 1.
+     knockbackResistance: 0 # knockback resistance is a value between 0 and 1.
    netheriteChestplate:
      material: NETHERITE_CHESTPLATE
      armour: 8
-     toughness: 5
+     toughness: 2
      extraDurabilityHits: 1
      knockbackResistance: 0
    netheriteLeggings:
      material: NETHERITE_LEGGINGS
      armour: 6
-     toughness: 5
+     toughness: 2
      extraDurabilityHits: 1
      knockbackResistance: 0
    netheriteBoots:
      material: NETHERITE_BOOTS
      armour: 4
-     toughness: 5
+     toughness: 2
      extraDurabilityHits: 1
      knockbackResistance: 0
 


### PR DESCRIPTION
Changed the knockback calculations a bit so knockback swords are fixed; added 'knockbackLevelMultiplier' to control the increased knockback per extra level of knockback enchantment.

Added 'extraDurabilityHits' for armour; an integer representing how many extra hits a piece of armour can take before it loses a point of durability.

S4NTA and I were having trouble changing the stats (knockback resistance, armour points) of armour items after they'd been initially modified, so made changes in 'WeaponsModificationListener' to amend this bug.